### PR TITLE
Smooth publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This is a monorepo containing various Zengine Plugin development related librari
 | Name  | Version |
 | ------------- | ------------- |
 | PostRPC Client  | [![npm version](https://img.shields.io/npm/v/@zenginehq/post-rpc-client.svg?color=brightgreen)](https://www.npmjs.com/package/@zenginehq/post-rpc-client)  |
-| PostRPC Generator  | [![npm version](https://img.shields.io/npm/v/@zenginehq/post-rpc-generator.svg?color=brightgreen)](https://www.npmjs.com/package/@zenginehq/post-rpc-generator)  |
 | PostRPC Server  | [![npm version](https://img.shields.io/npm/v/@zenginehq/post-rpc-server.svg?color=brightgreen)](https://www.npmjs.com/package/@zenginehq/post-rpc-server)  |
 | Zengine SDK  | [![npm version](https://img.shields.io/npm/v/@zenginehq/zengine-sdk.svg?color=brightgreen)](https://www.npmjs.com/package/@zenginehq/zengine-sdk)  |
 | Zengine SDK React  | [![npm version](https://img.shields.io/npm/v/@zenginehq/react-sdk.svg?color=brightgreen)](https://www.npmjs.com/package/@zenginehq/react-sdk) |
@@ -21,16 +20,16 @@ This is a monorepo containing various Zengine Plugin development related librari
 - Install [Lerna](https://lerna.js.org/): `npm i -g lerna`
 - Run dev script: `lerna run watch --parallel`
 
-## Publishing packages
+## Publishing
+
+After any code or docs change has been made, publish to npm and/or the documentation site with these commands. Lerna will take care of intelligently determining what changed and where to publish it. You need only occasionally determine the semver bump (Lerna usually gets that right too though).
 
 - First build all packages: `lerna run build`
-- Publish! `lerna publish --message "chore: release"`
-- Publish documentation: `lerna run docs:publish`
+- Publish! `lerna publish --message "chore: release"` (see note)
 
 _Notes_
 - Due to our [commitlint](https://github.com/conventional-changelog/commitlint) rules the default 
-commit message for publishing fails, so we gotta override it... PRs welcome to overcome!
-- Since the docs are a private package not on npm `lerna publish` ignores it so we do it ourselves
+commit message for publishing fails, so this valid message argument is required.
 
 
 ## Wishlist

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a monorepo containing various Zengine Plugin development related librari
 
 - First build all packages: `lerna run build`
 - Publish! `lerna publish --message "chore: release"`
-- Publish documentation: `npm run docs:publish`
+- Publish documentation: `lerna run docs:publish`
 
 _Notes_
 - Due to our [commitlint](https://github.com/conventional-changelog/commitlint) rules the default 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "@zenginehq/plugin-sdk",
   "private": true,
   "scripts": {
-    "commitmsg": "commitlint -e $GIT_PARAMS",
-    "docs:build": "cd packages/zengine-plugin-docs; npm run build",
-    "docs:deploy": "cd packages/zengine-plugin-docs; npm run deploy",
-    "docs:publish": "cd packages/zengine-plugin-docs; npm run publish"
+    "commitmsg": "commitlint -e $GIT_PARAMS"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@zenginehq/plugin-sdk",
   "private": true,
   "scripts": {
-    "commitmsg": "commitlint -e $GIT_PARAMS"
+    "commitmsg": "commitlint -e $GIT_PARAMS",
+    "postpublish": "lerna run docs:publish"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/packages/zengine-plugin-docs/CHANGELOG.md
+++ b/packages/zengine-plugin-docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.12](https://github.com/ZengineHQ/plugin-sdk/compare/zengine-plugin-docs@0.1.11...zengine-plugin-docs@0.1.12) (2020-03-26)
+
+**Note:** Version bump only for package zengine-plugin-docs
+
+
+
+
+
 ## [0.1.11](https://github.com/ZengineHQ/plugin-sdk/compare/zengine-plugin-docs@0.1.10...zengine-plugin-docs@0.1.11) (2020-03-26)
 
 **Note:** Version bump only for package zengine-plugin-docs

--- a/packages/zengine-plugin-docs/CHANGELOG.md
+++ b/packages/zengine-plugin-docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.11](https://github.com/ZengineHQ/plugin-sdk/compare/zengine-plugin-docs@0.1.10...zengine-plugin-docs@0.1.11) (2020-03-26)
+
+**Note:** Version bump only for package zengine-plugin-docs
+
+
+
+
+
 ## [0.1.10](https://github.com/ZengineHQ/plugin-sdk/compare/zengine-plugin-docs@0.1.9...zengine-plugin-docs@0.1.10) (2020-03-26)
 
 **Note:** Version bump only for package zengine-plugin-docs

--- a/packages/zengine-plugin-docs/CHANGELOG.md
+++ b/packages/zengine-plugin-docs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.10](https://github.com/ZengineHQ/plugin-sdk/compare/zengine-plugin-docs@0.1.9...zengine-plugin-docs@0.1.10) (2020-03-26)
+
+**Note:** Version bump only for package zengine-plugin-docs
+
+
+
+
+
 ## [0.1.9](https://github.com/ZengineHQ/plugin-sdk/compare/zengine-plugin-docs@0.1.8...zengine-plugin-docs@0.1.9) (2020-03-25)
 
 **Note:** Version bump only for package zengine-plugin-docs

--- a/packages/zengine-plugin-docs/package-lock.json
+++ b/packages/zengine-plugin-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zengine-plugin-docs",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/zengine-plugin-docs/package-lock.json
+++ b/packages/zengine-plugin-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zengine-plugin-docs",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/zengine-plugin-docs/package-lock.json
+++ b/packages/zengine-plugin-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zengine-plugin-docs",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/zengine-plugin-docs/package.json
+++ b/packages/zengine-plugin-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zengine-plugin-docs",
   "description": "Storybook documentation for Zengine Plugin SDK packages",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "scripts": {
     "start": "start-storybook -p 9009 -s public --quiet",

--- a/packages/zengine-plugin-docs/package.json
+++ b/packages/zengine-plugin-docs/package.json
@@ -7,8 +7,7 @@
     "start": "start-storybook -p 9009 -s public --quiet",
     "watch": "start-storybook -p 9009 -s public --quiet",
     "build": "build-storybook -s public --quiet",
-    "deploy": "storybook-to-ghpages",
-    "release": "standard-version -t ''; npm run deploy-storybook"
+    "postpublish": "npm run build && storybook-to-ghpages"
   },
   "author": "Alex Weber <alexweber@mailfence.com>",
   "homepage": "https://github.com/ZengineHQ/plugin-sdk#readme",

--- a/packages/zengine-plugin-docs/package.json
+++ b/packages/zengine-plugin-docs/package.json
@@ -7,7 +7,7 @@
     "start": "start-storybook -p 9009 -s public --quiet",
     "watch": "start-storybook -p 9009 -s public --quiet",
     "build": "build-storybook -s public --quiet",
-    "publish": "npm run build && storybook-to-ghpages"
+    "docs:publish": "npm run build && storybook-to-ghpages"
   },
   "author": "Alex Weber <alexweber@mailfence.com>",
   "homepage": "https://github.com/ZengineHQ/plugin-sdk#readme",

--- a/packages/zengine-plugin-docs/package.json
+++ b/packages/zengine-plugin-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zengine-plugin-docs",
   "description": "Storybook documentation for Zengine Plugin SDK packages",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "scripts": {
     "start": "start-storybook -p 9009 -s public --quiet",

--- a/packages/zengine-plugin-docs/package.json
+++ b/packages/zengine-plugin-docs/package.json
@@ -7,7 +7,7 @@
     "start": "start-storybook -p 9009 -s public --quiet",
     "watch": "start-storybook -p 9009 -s public --quiet",
     "build": "build-storybook -s public --quiet",
-    "postpublish": "npm run build && storybook-to-ghpages"
+    "publish": "npm run build && storybook-to-ghpages"
   },
   "author": "Alex Weber <alexweber@mailfence.com>",
   "homepage": "https://github.com/ZengineHQ/plugin-sdk#readme",

--- a/packages/zengine-plugin-docs/package.json
+++ b/packages/zengine-plugin-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zengine-plugin-docs",
   "description": "Storybook documentation for Zengine Plugin SDK packages",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "scripts": {
     "start": "start-storybook -p 9009 -s public --quiet",

--- a/packages/zengine-plugin-docs/src/index.stories.js
+++ b/packages/zengine-plugin-docs/src/index.stories.js
@@ -27,17 +27,16 @@ export const Introduction = () => (
 
     <dl>
       <dt><Button theme="link" classes="p-0" onClick={ linkTo('ZengineSDK|Welcome') }>Zengine SDK</Button></dt>
-      <dd>A cohesive set of libraries for interacting with the Zengine API</dd>
+      <dd>Fundamental JavaScript libraries for interacting with the Zengine API and hooking into Zengine Admin App behaviors</dd>
 
-      <dt><Button theme="link" classes="p-0" onClick={ linkTo('ZengineSDKReact|Welcome') }>Zengine SDK React</Button></dt>
-      <dd>React wrappers and components for working with Zengine SDK</dd>
+      <dt><Button theme="link" classes="p-0" onClick={ linkTo('ZengineSDKReact|Welcome') }>Zengine SDK for React</Button></dt>
+      <dd>React-specific components and hooks for working with the Zengine SDK</dd>
 
       <dt><Button theme="link" classes="p-0" onClick={ linkTo('ZengineUI|Welcome') }>Zengine UI</Button></dt>
       <dd>Beautiful, responsive styles using a custom Bootstrap theme for use with Zengine Plugins</dd>
 
-      <dt><Button theme="link" classes="p-0" onClick={ linkTo('ZengineUIReact|Welcome') }>Zengine UI React</Button></dt>
-      <dd>Robust React atomic design components for Zengine Plugins, used with Zengine UI</dd>
-
+      <dt><Button theme="link" classes="p-0" onClick={ linkTo('ZengineUIReact|Welcome') }>Zengine UI for React</Button></dt>
+      <dd>Robust React components for Zengine Plugins based on Zengine UI</dd>
     </dl>
   </>
 );


### PR DESCRIPTION
got the publish command to run in line with normal lerna publish, so we don't have to worry about semver bumps or manual docs deploys. Just use `lerna publish --message "chore: release"` for everything.